### PR TITLE
fix state machine step name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ plugins:
 
 custom:
   stepFunctionsOffline:
-    stepOne: firstLambda #(v2.0)
+    FirstLambda: firstLambda #(v2.0)
     # ...
     # ...
-    stepTwo: secondLambda #(v2.0)
+    SecondLambda: secondLambda #(v2.0)
 
 functions:
     firstLambda:
@@ -97,7 +97,7 @@ stepFunctions:
 ```
 
 Where:
-- `StepOne` is the name of step in state machine
+- `FirstLambda` is the name of step in state machine
 - `firstLambda` is the name of function in section **functions**
 
 # Run Plugin


### PR DESCRIPTION
The names of `stepOne` and `stepTwo` in the README are very confusing about how to name the configuration in `custom.stepFunctionsOffline`, this to me seems clearer and correct based on the example?