### PR TITLE
Handle functions when they are in array

### DIFF
--- a/build.js
+++ b/build.js
@@ -86,7 +86,17 @@ module.exports = {
             //before each task restore global default env variables
             process.env = Object.assign({}, this.environmentVariables);
             let f = this.variables[currentStateName];
-            f = this.functions[f];
+
+            if (Array.isArray(this.functions) && this.functions.length > 0) {
+                let functions = {};
+                this.functions.forEach((fns) => {
+                    functions = Object.assign(functions, fns);
+                });
+                f = functions[f];
+            } else {
+                f = this.functions[f];
+            }
+
             if (!f) {
                 this.cliLog(`Function "${currentStateName}" does not presented in serverless manifest`);
                 process.exit(1);


### PR DESCRIPTION
Issue:

When use multiple resource files combined with resources inside the serverless.yml

``` yaml
# serverless.yml
functions:
  - ${file(configs/functions/funcionts1.yml)}
  - ${file(configs/functions/funcionts2.yml)}
  - ${file(configs/functions/funcionts3.yml)}
```

The `this.functions` is an array. Therefore, it returns error here

``` javascript
  _states(currentState, currentStateName) {
      switch (currentState.Type) {
      case 'Task': // just push task to general array
          //before each task restore global default env variables
          process.env = Object.assign({}, this.environmentVariables);
          let f = this.variables[currentStateName];
          
          console.log(this.functions); /// [{}, {}, {}] 
          
          f = this.functions[f];
          if (!f) {
              this.cliLog(`Function "${currentStateName}" does not presented in serverless.yml`);
              process.exit(1);
          }
  .....
  }
```
Expected results,
It should find the right function in the resources file.