### PR TITLE
feat| Added support for custom build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,17 @@ Where:
 
 # Run Plugin
 ```bash
-sls step-functions-offline --stateMachine={{name}} --event={{path to event file}}
+sls step-functions-offline --stateMachine={{name}} --event={{path to event file}} --buildDir={{build-path}}
 ```
 
-- `name`: name of state machine in section state functions. In example above it's `foo`.
+- `stateMachine`: name of state machine in section state functions. In example above it's `foo`.
 - `event`: input values for execution in JSON format (optional)
+- `buildDir`: path to the build directory, eg: .webpack/.build (optional)
+
+In case you have a custom build directory use:
+ ```bash
+sls step-functions-offline --stateMachine={{name}} --event={{path to event file}} --buildDir={{build-path}}
+```
 
 If you want to know where you are (in offline mode or not) you can use env variable `STEP_IS_OFFLINE`.
 

--- a/build.js
+++ b/build.js
@@ -17,7 +17,8 @@ module.exports = {
     // },
     //
     _findFunctionPathAndHandler(functionHandler) {
-        const dir = path.dirname(functionHandler);
+        const buildDir = this.options.buildDir ? `${this.options.buildDir}/` : '';
+        const dir = `${buildDir}${path.dirname(functionHandler)}`;
         const handler = path.basename(functionHandler);
         const splitHandler = handler.split('.');
         const filePath = `${dir}/${splitHandler[0]}.js`;


### PR DESCRIPTION
The plugin doesn't work properly with a Typescript project. It uses the wrong path to the function file.
To fix this issue I added an option to specify the build directory.

```
sls step-functions-offline --stateMachine=FirstLambda --event={{path to event file}} --buildDir=.webpack/build
```