### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,15 +35,18 @@ class StepFunctionsOfflinePlugin {
                 options: {
                     stateMachine: {
                         usage: 'The stage used to execute.',
-                        required: true
+                        required: true,
+                        type: 'string'
                     },
                     event: {
                         usage: 'File where is values for execution in JSON format',
-                        shortcut: 'e'
+                        shortcut: 'e',
+                        type: 'string'
                     },
                     detailedLog: {
                         usage: 'Option which enables detailed logs',
-                        shortcut: 'l'
+                        shortcut: 'l',
+                        type: 'boolean'
                     }
                 }
             }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - StepFunctionsOfflinePlugin for "stateMachine", "event", "detailedLog"
```